### PR TITLE
Tidy `f_moist_rothc`

### DIFF
--- a/R/f_moist_rothc.R
+++ b/R/f_moist_rothc.R
@@ -17,75 +17,38 @@
 #' @author Marcos Alves
 #' @import SoilR
 #' @export
-#'
-
 f_moist_rothc <- function(pp, et, s_thick, pclay, pE = 1.0, soil_cover = TRUE) {
   if (length(et) != length(pp)) {
     stop("pp and et must have the same lengh")
   }
-  soil_cover <- !as.logical(soil_cover)
+  
+  soil_cover <- as.logical(soil_cover)
   if (length(soil_cover) > 1) {
     if (length(soil_cover) != length(pp) | length(soil_cover) != length(et)) {
       stop("pp, et and soil_cover must have the same lengh")
     }
-    fwBare <- fW.RothC(
+    
+    fw_bare <- fW.RothC(
       P = pp, E = et,
       S.Thick = s_thick, pClay = pclay,
       pE = pE, bare = TRUE
     )$b
-    fwCoverd <- fW.RothC(
+    
+    fw_covered <- fW.RothC(
       P = pp, E = et,
       S.Thick = s_thick, pClay = pclay,
       pE = pE, bare = FALSE
     )$b
-    fw <- fwBare
-    fw[!soil_cover] <- fwCoverd[!soil_cover]
+    
+    fw <- fw_bare
+    fw[soil_cover] <- fw_covered[soil_cover]
   } else {
     fw <- fW.RothC(
       P = pp, E = et,
       S.Thick = s_thick, pClay = pclay,
-      pE = pE, bare = soil_cover
+      pE = pE, bare = !soil_cover
     )$b
+    
   }
   return(fw)
 }
-
-
-f_moist_rothc2 <- function(pp, et, s_thick, pclay, pE = 1.0, soil_cover = TRUE) {
-  if (length(et) != length(pp)) {
-    stop("pp and et must have the same lengh")
-  }
-  soil_cover <- !as.logical(soil_cover)
-  if (length(soil_cover) > 1) {
-    if (length(soil_cover) != length(pp) | length(soil_cover) != length(et)) {
-      stop("pp, et and soil_cover must have the same lengh")
-    }
-    fwBare <- fW.RothC(
-      P = pp, E = et,
-      S.Thick = s_thick, pClay = pclay,
-      pE = pE, bare = TRUE
-    )$b
-    fwCoverd <- fW.RothC(
-      P = pp, E = et,
-      S.Thick = s_thick, pClay = pclay,
-      pE = pE, bare = FALSE
-    )$b
-    fw <- fwBare
-    fw[!soil_cover] <- fwCoverd[!soil_cover]
-  } else {
-    fw <- fW.RothC(
-      P = pp, E = et,
-      S.Thick = s_thick, pClay = pclay,
-      pE = pE, bare = soil_cover
-    )$b
-  }
-  return(fw)
-}
-
-
-
-fwBare <- fW.RothC2(
-  P = c(1, 2, 3), E = c(1, 2, 3),
-  S.Thick = 1, pClay = 1,
-  pE = 1, bare = c(1, 1, 0)
-)$b


### PR DESCRIPTION
- Make the logical behaviour around `soil_cover` clearer,
- Remove `f_moist_rothc2` -- not used anywhere.

The diff created for this is bizarre, look at the full file instead.